### PR TITLE
Remove Partial<T> from complete.success

### DIFF
--- a/src/lib/ZBWorkerBase.ts
+++ b/src/lib/ZBWorkerBase.ts
@@ -272,7 +272,7 @@ export class ZBWorkerBase<
 			retries?: number
 		) => this.failJob({ job, errorMessage, retries })
 
-		const succeedJob = (job: ZB.Job) => (completedVariables?: Partial<T>) =>
+		const succeedJob = (job: ZB.Job) => (completedVariables?: T) =>
 			this.completeJob(job.key, completedVariables ?? {})
 
 		const errorJob = (job: ZB.Job) => (

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -63,9 +63,7 @@ export interface CompleteFn<WorkerOutputVariables> {
 	 * Complete the job with a success, optionally passing in a state update to merge
 	 * with the workflow variables on the broker.
 	 */
-	success: (
-		updatedVariables?: Partial<WorkerOutputVariables>
-	) => Promise<boolean>
+	success: (updatedVariables?: WorkerOutputVariables) => Promise<boolean>
 	/**
 	 * Fail the job with an informative message as to the cause. Optionally pass in a
 	 * value remaining retries. If no value is passed for retries then the current retry


### PR DESCRIPTION
Fixes #198

## Proposed Changes

  - Change worker output variables type from `Partial<T>` to `T`

