### PR TITLE
Fixes layout bug in oauth section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,16 +364,14 @@ const zbc = new ZBClient({
 
 Or you can put the file paths into the environment in the following variables:
 
-```
-
 ZEEBE_CLIENT_SSL_ROOT_CERTS_PATH
 ZEEBE_CLIENT_SSL_PRIVATE_KEY_PATH
 ZEEBE_CLIENT_SSL_CERT_CHAIN_PATH
+```
 
 # Enable TLS
-
+```
 ZEEBE_SECURE_CONNECTION=true
-
 ````
 
 In this case, they will be passed to the constructor automatically.


### PR DESCRIPTION
:wave: First of all, thank you for the amazing work on zeebe!

I've noticed a minor layout bug in the tls / oauth section in the readme, that lead to a broken link in the table of contents. This pull request fixes this. I hope it was ok not open an issue first.

## Proposed Changes
- Add missing ``` to fix code layout of the previous section.
